### PR TITLE
Add Speaker Page Design

### DIFF
--- a/years/2024/lib/nvc_web/controllers/page_controller.ex
+++ b/years/2024/lib/nvc_web/controllers/page_controller.ex
@@ -6,4 +6,5 @@ defmodule NvcWeb.PageController do
 
   def coc(conn, _params), do:
     render(conn, :coc)
+  def speaker(conn, _params), do: render(conn, :speaker)
 end

--- a/years/2024/lib/nvc_web/controllers/page_html/speaker.html.heex
+++ b/years/2024/lib/nvc_web/controllers/page_html/speaker.html.heex
@@ -1,0 +1,49 @@
+<.main>
+  <.header>
+    <:title>
+      Josh Medeski
+    </:title>
+  </.header>
+
+  <a href="/speakers" class="underline">← back to speakers</a>
+
+  <div class="relative p-6 block bg-[#BDE1F6] before:border-4 before:w-full before:border-[#BDE1F6] before:-mt-8 before:-ml-4 before:absolute before:h-full before:bg-blend-difference before:hover:translate-y-4 transition-all space-y-2">
+    <h2><strong class="text-primary">Talk:</strong> Serving our LLM Overloards</h2>
+    <p>
+      Join me as we explore the most popular AI plugins for Neovim, guiding you to choose the best fit for your workflow. Discover how these tools can significantly boost your productivity and transform your coding experience.
+    </p>
+    <div class="flex items-center gap-4">
+      <div><strong class="text-primary">Time:</strong> 10:00am</div>
+      <div><strong class="text-primary">Duration:</strong> 30 mins</div>
+    </div>
+  </div>
+
+  <h2>About Josh</h2>
+
+  <div>
+    <img
+      src="https://www.joshmedeski.com/joshmedeski-profile-circle.png"
+      alt="Josh Medeski"
+      class="max-w-[200px] h-auto float-right pl-1 pb-1"
+      style="clip-path: circle(50%); shape-outside: circle(50%);"
+    />
+
+    <p>
+      Josh is a full-stack developer and content creator. He is the creator of the popular tmux session manager, sesh. He enjoys building terminal-based productivity tools for developers in his free time and often livestreams his progress on open-source projects. He lives in Houston, Texas, USA and enjoys listening to vinyl and playing video games in his free time.
+    </p>
+  </div>
+
+  <h3>Connect with Josh</h3>
+
+  <ul class="list-disc list-inside">
+    <li>
+      <a href="https://joshmedeski.com" class="underline">joshmedeski.com</a>
+    </li>
+    <li>
+      <a href="https://youtube.com/joshmedeski" class="underline">youtube.com/joshmedeski</a>
+    </li>
+    <li>
+      <a href="https://x.com/joshmedeski" class="underline">x.com/joshmedeski</a>
+    </li>
+  </ul>
+</.main>

--- a/years/2024/lib/nvc_web/router.ex
+++ b/years/2024/lib/nvc_web/router.ex
@@ -29,6 +29,7 @@ defmodule NvcWeb.Router do
 
     get    "/privacy", PageController, :privacy
     get    "/coc", PageController, :coc
+    get "/speakers/:slug", PageController, :speaker
 
   end
 


### PR DESCRIPTION
Creates a `/speakers/:slug` route with a hard-coded sample of an individual speaker page.

<img width="1216" alt="SCR-20241016-jwbb" src="https://github.com/user-attachments/assets/a2f2c6c3-7e4a-4ca2-af33-2c5a2f52b35c">
